### PR TITLE
Use acceptable name for GitHub token secret

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -24,7 +24,7 @@ jobs:
         run: npm run build
       - name: Release
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GH_TOKEN }}
           NPM_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npx semantic-release
       - name: Code Coverage

--- a/README.md
+++ b/README.md
@@ -45,6 +45,11 @@ rm *.mybak
 
 Add your npm token to your GitHub repository secrets as `NPM_TOKEN`.
 
+
+### Add GitHub Token
+
+Add your [GitHub personal access token](https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/creating-a-personal-access-token) to your GitHub repository secrets as `GH_TOKEN`.
+
 ### Add Codecov integration
 
 Enable the Codecov GitHub App [here](https://github.com/apps/codecov).


### PR DESCRIPTION
### Change name for GitHub token

GitHub doesn't allow you to add a repository secret named `GITHUB_*`. This PR changes the name to `GH_TOKEN` and also adds instructions to the readme.

### Pull-Request Checklist

- [x] Code is up-to-date with the `main` branch
- [x] `npm run lint` passes with this change
- [x] `npm run test` passes with this change
- [ ] (n/a) This pull request links relevant issues as `Fixes #0000`
- [ ] (n/a) There are new or updated unit tests validating the change
- [x] Documentation has been updated to reflect this change
- [ ] The new commits follow conventions outlined in the [conventional commit spec](https://www.conventionalcommits.org/en/v1.0.0/)

